### PR TITLE
increase coverage by specifying default_app_config

### DIFF
--- a/edpcmentoring/autonag/__init__.py
+++ b/edpcmentoring/autonag/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'autonag.apps.AutonagConfig'

--- a/edpcmentoring/frontend/__init__.py
+++ b/edpcmentoring/frontend/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'frontend.apps.FrontendConfig'

--- a/edpcmentoring/projectlight/__init__.py
+++ b/edpcmentoring/projectlight/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'projectlight.apps.ProjectlightConfig'


### PR DESCRIPTION
Some applications did not set default_app_config in their `__init__.py` file.
This had the dual effect of a) not honouring any customisation in the AppConfig
derived classes and b) putting a ceiling on our code coverage.