### PR TITLE
Add in a simple notification on new relationship

### DIFF
--- a/docs/autonag.rst
+++ b/docs/autonag.rst
@@ -1,0 +1,8 @@
+Notifying and reminding users
+=============================
+
+The :py:mod:`autonag` application takes care of notifying users of events
+they should be aware of and reminding them of tasks they have yet to complete.
+
+.. automodule:: autonag
+    :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,3 +8,4 @@ EDPC Mentoing Scheme Database
     mentoring
     matchmaking
     cuedmembers
+    autonag

--- a/edpcmentoring/autonag/__init__.py
+++ b/edpcmentoring/autonag/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'autonag.apps.AutonagConfig'

--- a/edpcmentoring/autonag/apps.py
+++ b/edpcmentoring/autonag/apps.py
@@ -1,5 +1,13 @@
 from django.apps import AppConfig
-
+from django.db.models.signals import post_migrate
 
 class AutonagConfig(AppConfig):
     name = 'autonag'
+    verbose_name = 'User notification and reminding'
+
+    def ready(self):
+        # import signal handlers
+        import autonag.signalhandlers as handlers
+
+        # register notification creation handler
+        post_migrate.connect(handlers.create_notice_types, sender=self)

--- a/edpcmentoring/autonag/signalhandlers.py
+++ b/edpcmentoring/autonag/signalhandlers.py
@@ -1,0 +1,26 @@
+from django.conf import settings
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from pinax.notifications.models import send
+
+from mentoring.models import Relationship
+
+@receiver(post_save, sender=Relationship, dispatch_uid='relationship_create')
+def relationship_post_save_handler(created, instance, **_):
+    # Only notify if this is a new *active* relationship
+    if not created or not instance.is_active:
+        return
+
+    send([instance.mentor], 'new_mentee', {'relationship': instance})
+    send([instance.mentee], 'new_mentor', {'relationship': instance})
+
+def create_notice_types(**_):
+    if 'pinax.notifications' in settings.INSTALLED_APPS:
+        from pinax.notifications.models import NoticeType
+        print('Creating notices for autonag')
+        NoticeType.create(
+            'new_mentor', 'New mentor', 'you have a new mentor')
+        NoticeType.create(
+            'new_mentee', 'New mentee', 'you have a new mentee')
+    else:
+        print('Skipping creation of NoticeTypes as notification app not found')

--- a/edpcmentoring/autonag/tests.py
+++ b/edpcmentoring/autonag/tests.py
@@ -1,3 +1,50 @@
+from django.core import mail
 from django.test import TestCase
 
-# Create your tests here.
+from cuedmembers.models import Member
+from mentoring.models import Relationship
+
+class NewRelationshipTestCase(TestCase):
+    fixtures = ['cuedmembers/test_users_and_members']
+
+    def test_email_sent_on_new_relationship(self):
+        """Creating a new relationship should notify the members."""
+        u1, u2 = [m.user for m in Member.objects.active()[3:5]]
+        self.assertEqual(Relationship.objects.filter(
+            mentor=u1, mentee=u2).count(), 0)
+        self.assertEqual(len(mail.outbox), 0)
+        Relationship.objects.create(mentor=u1, mentee=u2)
+        self.assertEqual(Relationship.objects.filter(
+            mentor=u1, mentee=u2).count(), 1)
+        self.assertEqual(len(mail.outbox), 2)
+
+        mail_counts = {}
+        for m in mail.outbox:
+            for addr in m.to:
+                mail_counts[addr] = mail_counts.get(addr, 0) + 1
+        self.assertEqual(len(mail_counts), 2)
+        self.assertEqual(mail_counts[u1.email], 1)
+        self.assertEqual(mail_counts[u2.email], 1)
+
+    def test_email_not_sent_on_new_inactive_relationship(self):
+        """Creating a new inactive relationship should not notify the members.
+
+        """
+        u1, u2 = [m.user for m in Member.objects.active()[3:5]]
+        self.assertEqual(Relationship.objects.filter(
+            mentor=u1, mentee=u2).count(), 0)
+        Relationship.objects.create(mentor=u1, mentee=u2, is_active=False)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_email_not_sent_on_modifying_existing(self):
+        """Re-saving an existing relationship should not notify the members.
+
+        """
+        u1, u2 = [m.user for m in Member.objects.active()[3:5]]
+        self.assertEqual(Relationship.objects.filter(
+            mentor=u1, mentee=u2).count(), 0)
+        r = Relationship.objects.create(mentor=u1, mentee=u2)
+        mail.outbox = []
+        self.assertEqual(len(mail.outbox), 0)
+        r.save()
+        self.assertEqual(len(mail.outbox), 0)

--- a/edpcmentoring/edpcmentoring/settings.py
+++ b/edpcmentoring/edpcmentoring/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sites',
 
     'crispy_forms',
     'debug_toolbar',
@@ -45,6 +46,7 @@ INSTALLED_APPS = [
     'django_tables2',
     'email_log',
     'ucamwebauth',
+    'pinax.notifications',
 
     'cuedmembers',
     'matching',
@@ -110,6 +112,8 @@ if 'DATABASE_URL' in os.environ:
     # Update database configuration with $DATABASE_URL.
     db_from_env = dj_database_url.config(conn_max_age=500)
     DATABASES['default'].update(db_from_env)
+
+SITE_ID = 1
 
 FILTERS_HELP_TEXT_FILTER = False
 

--- a/edpcmentoring/edpcmentoring/urls.py
+++ b/edpcmentoring/edpcmentoring/urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'', include('ucamwebauth.urls')),
     url(r'^matching/', include('matching.urls')),
+    url(r'^notifications/', include('pinax.notifications.urls')),
     url(r'', include('frontend.urls')),
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ psycopg2
 # Required for the heroku buildpack to install libffi
 cffi
 cryptography
+pinax-notifications


### PR DESCRIPTION
This is the first bit of functionality for the `autonag` application. It is mostly to test that a) the plumbing works and b) that when deployed to Heroku we don't start spamming people!

After merging, check that emails are logged and check that emails are not actually sent on Heroku by manually setting the email address of a user and adding them to a relationship.

This should allow for the easy addition of user notifications going forward.

Documenting the purpose and design of autonag is still required.