### PR TITLE
Increase coverage of cuedmembers application

### DIFF
--- a/edpcmentoring/cuedmembers/management/commands/importcuedmembers.py
+++ b/edpcmentoring/cuedmembers/management/commands/importcuedmembers.py
@@ -25,14 +25,11 @@ or https URL to a CSV file located on a remote server.
 from future.standard_library import install_aliases
 install_aliases()
 
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
 import sys
 from urllib.parse import urlparse
 
 from django.core.management.base import BaseCommand
+from django.utils.six import StringIO
 import requests
 
 from ...csv import read_members_from_csv

--- a/edpcmentoring/cuedmembers/tests/test_csv.py
+++ b/edpcmentoring/cuedmembers/tests/test_csv.py
@@ -1,18 +1,10 @@
 from contextlib import closing
 import csv
 
-# Python 2 does indeed have io.StringIO but it only accepts unicode input which
-# is incompatible with the csv module (yay, unicode!). Work around this by
-# trying to import the old-style StringIO module from Python 2 and, if this
-# fails, try the new-style io.StringIO.
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
-
 import random
 
 from django.test import TestCase
+from django.utils.six import StringIO
 
 from .. import get_member_group
 from ..csv import write_members_to_csv, read_members_from_csv

--- a/edpcmentoring/cuedmembers/tests/test_managementcommands.py
+++ b/edpcmentoring/cuedmembers/tests/test_managementcommands.py
@@ -1,3 +1,4 @@
+import csv
 import os
 import shutil
 import tempfile
@@ -51,6 +52,27 @@ class ImportCUEDMembersTestCase(TemporaryDirectoryTestCase):
         u1 = Member.objects.filter(user__username='test0001').first().user
         self.assertEqual(u1.email, 'test0001@mailinator.com')
 
+class DumpCUEDMembersTestCase(TemporaryDirectoryTestCase):
+    fixtures = ['cuedmembers/test_users_and_members']
+
+    def test_basic_dump(self):
+        outpath = os.path.join(self.tmpdir, 'output.csv')
+        with open(outpath, 'w') as f:
+            call_command('dumpactivecuedmembers', stdout=f)
+
+        with open(outpath) as f:
+            r = csv.reader(f)
+            rows = list(r)
+
+        # strip heading
+        rows = rows[1:]
+
+        self.assertEqual(len(rows), Member.objects.active().count())
+        for row in rows:
+            username = row[0]
+            m = Member.objects.filter(user__username=username).first()
+            self.assertIsNotNone(m)
+            self.assertTrue(m.is_active)
 
 # Two CSV files with different sets of users
 

--- a/edpcmentoring/cuedmembers/tests/test_managementcommands.py
+++ b/edpcmentoring/cuedmembers/tests/test_managementcommands.py
@@ -1,0 +1,74 @@
+import os
+import shutil
+import tempfile
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from ..models import Member
+
+class TemporaryDirectoryTestCase(TestCase):
+    """A TestCase which creates a temporary directory for each test whose path
+    is available as the "tmpdir" attribute.
+
+    """
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+class ImportCUEDMembersTestCase(TemporaryDirectoryTestCase):
+    def test_csv_import(self):
+        self.assertEqual(Member.objects.active().count(), 0)
+        inpath = os.path.join(self.tmpdir, 'input.csv')
+        with open(inpath, 'w') as f:
+            f.write(MEMBERS_CSV_1)
+        call_command('importcuedmembers', inpath)
+        self.assertEqual(Member.objects.active().count(), 6)
+
+    def test_import_deactivates_members(self):
+        self.assertEqual(Member.objects.active().count(), 0)
+        inpath = os.path.join(self.tmpdir, 'input.csv')
+        with open(inpath, 'w') as f:
+            f.write(MEMBERS_CSV_1)
+        call_command('importcuedmembers', inpath)
+        self.assertEqual(Member.objects.active().count(), 6)
+        inpath = os.path.join(self.tmpdir, 'input.csv')
+        with open(inpath, 'w') as f:
+            f.write(MEMBERS_CSV_2)
+        call_command('importcuedmembers', inpath)
+        self.assertEqual(Member.objects.active().count(), 5)
+        self.assertEqual(Member.objects.all().count(), 7)
+
+    def test_email_domain(self):
+        self.assertEqual(Member.objects.active().count(), 0)
+        inpath = os.path.join(self.tmpdir, 'input.csv')
+        with open(inpath, 'w') as f:
+            f.write(MEMBERS_CSV_1)
+        call_command('importcuedmembers', '-e', 'mailinator.com', inpath)
+        self.assertEqual(Member.objects.active().count(), 6)
+        u1 = Member.objects.filter(user__username='test0001').first().user
+        self.assertEqual(u1.email, 'test0001@mailinator.com')
+
+
+# Two CSV files with different sets of users
+
+MEMBERS_CSV_1 = '''
+crsid,status,surname,fnames,pref_name,room,phone,arrived,start_date,end_date,division,role_course,host_supervisor,research_group
+test0001,,Klein,Alexandra Corrina,Alexandra,,,,,,C,,,Materials Engineering
+test0002,,Herman,Verna Ibrahim Fletcher,Verna,,,,,,,,,
+test0004,,Kihn,Clementine,Clementine,,,,,,C,,,Engineering Design
+test0005,,Lindgren,Eric,Eric,,,,,,A,,,Turbomachinery
+test0006,,Torphy,Shirleyann Arden Minerva,Minerva,,,,,,,,,
+test0008,,Kling,Jorden,Jorden,,,,,,A,,,Turbomachinery
+'''.strip()
+
+MEMBERS_CSV_2 = '''
+crsid,status,surname,fnames,pref_name,room,phone,arrived,start_date,end_date,division,role_course,host_supervisor,research_group
+test0001,,Klein,Alexandra Corrina,Alexandra,,,,,,C,,,Materials Engineering
+test0003,,Emmerich,Pleasant,Pleasant,,,,,,A,,,Turbomachinery
+test0004,,Kihn,Clementine,Clementine,,,,,,C,,,Engineering Design
+test0006,,Torphy,Shirleyann Arden Minerva,Minerva,,,,,,,,,
+test0008,,Kling,Jorden,Jorden,,,,,,A,,,Turbomachinery
+'''.strip()

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ deps=
 commands=
     coverage erase
     coverage run edpcmentoring/manage.py test {posargs:edpcmentoring}
-    coverage report --skip-covered
     coverage html
 
 # A testenv which uses whichever Python 3 is installed on the system


### PR DESCRIPTION
Add some basic tests for the `importcuedmembers` and `dumpactivemembers` management commands. Increases coverage slightly and checks that the commands at least run.